### PR TITLE
Κάλυψη περίπτωσης σφάλματος χωρίς errorcode, αλλά με message

### DIFF
--- a/PHP/create_order.php
+++ b/PHP/create_order.php
@@ -52,7 +52,7 @@ if (isset($resultObj->ErrorCode) && $resultObj->ErrorCode==0){	//success when Er
 	echo '</br/><a href="http://demo.vivapayments.com/web/newtransaction.aspx?ref='.$orderId.'" >Make Payment</a>';
 } elseif (!isset($resultObj->ErrorCode)){
         $output = 'The following error occured: ' . $resultObj->Message;
-    } else{
+} else{
 	echo 'The following error occured: ' . $resultObj->ErrorText;
 }
 


### PR DESCRIPTION
Στο demo αυτό συμβαίνει όταν το merchant id είναι λάθος (δεν επιστρέφει error, επιστρέφει message) και η php πετάει warning με τον προηγούμενο κώδικα, ενώ δεν δείχνει ποτέ το μήνυμα που επιστρέφεται από το api.
